### PR TITLE
Remove ValidatedRSSPMetadata

### DIFF
--- a/src/main/kotlin/eu/europa/ec/eudi/rqes/CSCClient.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/rqes/CSCClient.kt
@@ -37,11 +37,12 @@ interface CSCClient :
             rsspId: String,
             ktorHttpClientFactory: KtorHttpClientFactory = DefaultHttpClientFactory,
         ): Result<CSCClient> = kotlin.runCatching {
-            val metadata = run {
-                val id = RSSPId(rsspId).getOrThrow()
-                val resolver = RSSPMetadataResolver(ktorHttpClientFactory)
-                resolver.resolve(id, cscClientConfig.locale).getOrThrow()
-            }
+            val metadata =
+                run {
+                    val id = RSSPId(rsspId).getOrThrow()
+                    val resolver = RSSPMetadataResolver(ktorHttpClientFactory)
+                    resolver.resolve(id, cscClientConfig.locale).getOrThrow()
+                }
             oauth2(cscClientConfig, metadata, ktorHttpClientFactory).getOrThrow()
         }
 
@@ -51,13 +52,7 @@ interface CSCClient :
             ktorHttpClientFactory: KtorHttpClientFactory = DefaultHttpClientFactory,
         ): Result<CSCClient> = runCatching {
             val oauth2AuthType =
-                rsspMetadata.authTypes.values
-                    .filterIsInstance<AuthType.OAuth2>()
-                    .firstOrNull()
-            requireNotNull(oauth2AuthType) {
-                "RSSP doesn't support OAUTH2"
-            }
-
+                requireNotNull(rsspMetadata.oauth2AuthType()) { "RSSP doesn't support OAUTH2" }
             val (authServerMetadata, grants) = oauth2AuthType
 
             val tokenEndpointClient = TokenEndpointClient(

--- a/src/test/kotlin/eu/europa/ec/eudi/rqes/MockData.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/rqes/MockData.kt
@@ -39,12 +39,11 @@ internal fun rsspMetadata() = RSSPMetadata(
     region = "IT",
     lang = Locale.forLanguageTag("en-US"),
     description = "An efficient remote signature service",
-    authTypes = AuthTypesSupported(
-        setOf(
-            AuthType.Basic,
-            AuthType.OAuth2(authorizationServerMetadata, setOf(Oauth2Grant.AuthorizationCode)),
-        ),
+    authTypes = setOf(
+        AuthType.Basic,
+        AuthType.OAuth2(authorizationServerMetadata, setOf(Oauth2Grant.AuthorizationCode)),
     ),
+
     methods = methods,
 )
 
@@ -56,23 +55,16 @@ internal fun rsspMetadataWithOAuth2Issuer() = RSSPMetadata(
     region = "IT",
     lang = Locale.forLanguageTag("en-US"),
     description = "An efficient remote signature service",
-    authTypes = AuthTypesSupported(
-        setOf(
-            AuthType.Basic,
-            AuthType.OAuth2(authorizationServerMetadata, setOf(Oauth2Grant.AuthorizationCode)),
-        ),
+    authTypes = setOf(
+        AuthType.Basic,
+        AuthType.OAuth2(authorizationServerMetadata, setOf(Oauth2Grant.AuthorizationCode)),
     ),
+
     methods = methods,
 )
 
 internal fun RSSPMetadata.withClientCredentialsFlow() = run {
-    copy(
-        authTypes = AuthTypesSupported(
-            setOf(
-                AuthType.OAuth2(authorizationServerMetadata, setOf(Oauth2Grant.ClientCredentials)),
-            ),
-        ),
-    )
+    copy(authTypes = setOf(AuthType.OAuth2(authorizationServerMetadata, setOf(Oauth2Grant.ClientCredentials))))
 }
 
 private val methods = listOf(


### PR DESCRIPTION
This PR removes intermediate class `ValidatedRSSPMetadata`, thus simplifying the API.

* Introduces a RSSPMetatadataContents which is paremeterizd on the way that an authorization server is represented
* Introduces a sealed interface AuthorizationServerRef with two cases, ByIssuerClaim and ByOAauth2Claim
