### PR TITLE
Update `documentWithSignature` type to `ByteArray` and use Base64 encoding in response handling

### DIFF
--- a/src/main/kotlin/eu/europa/ec/eudi/documentretrieval/ResponseDispatcher.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/documentretrieval/ResponseDispatcher.kt
@@ -45,7 +45,7 @@ sealed interface Consensus : Serializable {
      *  respond to the request
      */
     data class Positive(
-        val documentWithSignature: List<String>?,
+        val documentWithSignature: List<ByteArray>?,
         val signatureObject: List<String>?,
     ) : Consensus {
         init {

--- a/src/main/kotlin/eu/europa/ec/eudi/documentretrieval/internal/response/AuthorizationResponse.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/documentretrieval/internal/response/AuthorizationResponse.kt
@@ -36,7 +36,7 @@ internal sealed interface AuthorizationResponsePayload : Serializable {
         override val nonce: String?,
         override val state: String?,
         override val clientId: String,
-        val documentWithSignature: List<String>?,
+        val documentWithSignature: List<ByteArray>?,
         val signatureObject: List<String>?,
     ) : AuthorizationResponsePayload
 

--- a/src/main/kotlin/eu/europa/ec/eudi/documentretrieval/internal/response/DefaultResponseDispatcher.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/documentretrieval/internal/response/DefaultResponseDispatcher.kt
@@ -30,6 +30,7 @@ import io.ktor.utils.io.*
 import kotlinx.serialization.json.*
 import java.net.URI
 import java.net.URL
+import java.util.Base64
 
 /**
  * Default implementation of [Dispatcher]
@@ -113,8 +114,8 @@ internal object DirectPostForm {
         }
 
     fun of(p: AuthorizationResponsePayload): Map<String, String> {
-        fun MutableMap<String, String>.putDocumentWithSignature(documentWithSignature: List<String>) {
-            put(DOCUMENT_WITH_SIGNATURE, documentWithSignature.asParam())
+        fun MutableMap<String, String>.putDocumentWithSignature(documentWithSignature: List<ByteArray>) {
+            put(DOCUMENT_WITH_SIGNATURE, documentWithSignature.map { Base64.getEncoder().encode(it).decodeToString() }.asParam())
         }
 
         fun MutableMap<String, String>.putSignatureObject(signatureObject: List<String>) {

--- a/src/test/kotlin/DocumentRetrievalExample.kt
+++ b/src/test/kotlin/DocumentRetrievalExample.kt
@@ -21,7 +21,6 @@ import eu.europa.ec.eudi.rqes.SignaturesList
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import kotlinx.coroutines.runBlocking
-import java.io.ByteArrayInputStream
 import java.security.MessageDigest
 import java.time.Clock
 import java.time.Duration
@@ -74,24 +73,24 @@ fun main() {
                         }
                     }.map { it }
 
-                // document signing flow starts here, as shown in the Example.kt file
+                // the document signing flow starts here, as shown in the Example.kt file
 
-                // the output of the  signing flow is a list of signed documents and a list of signatures
+                // the output of the signing flow is a list of signed documents and a list of signatures
 
                 val signedDocuments =
                     listOf(
-                        ByteArrayInputStream("signed document".toByteArray()),
+                        "signed document content".toByteArray(),
                     )
                 val signatureList = SignaturesList(
                     listOf(
-                        Signature("signature"),
+                        Signature("signature content"),
                     ),
                 )
 
                 dispatch(
                     resolution.requestObject,
                     Consensus.Positive(
-                        documentWithSignature = signedDocuments.map { it.readAllBytes().decodeToString() },
+                        documentWithSignature = signedDocuments,
                         signatureObject = signatureList.signatures.map { it.value },
                     ),
                 )


### PR DESCRIPTION
Fixes #72