### PR TITLE
If RSSP is using oauth2 base URL instead of issuer, try the par endpoint if supported

### DIFF
--- a/api/eudi-lib-jvm-rqes-csc-kt.api
+++ b/api/eudi-lib-jvm-rqes-csc-kt.api
@@ -1994,10 +1994,6 @@ public final class eu/europa/ec/eudi/rqes/RSSPMethod : java/lang/Enum {
 	public static final field CredentialsList Leu/europa/ec/eudi/rqes/RSSPMethod;
 	public static final field CredentialsSendOTP Leu/europa/ec/eudi/rqes/RSSPMethod;
 	public static final field Info Leu/europa/ec/eudi/rqes/RSSPMethod;
-	public static final field Oauth2Authorize Leu/europa/ec/eudi/rqes/RSSPMethod;
-	public static final field Oauth2PushedAuthorize Leu/europa/ec/eudi/rqes/RSSPMethod;
-	public static final field Oauth2Revoke Leu/europa/ec/eudi/rqes/RSSPMethod;
-	public static final field Oauth2Token Leu/europa/ec/eudi/rqes/RSSPMethod;
 	public static final field SignaturesSignDoc Leu/europa/ec/eudi/rqes/RSSPMethod;
 	public static final field SignaturesSignHash Leu/europa/ec/eudi/rqes/RSSPMethod;
 	public static final field SignaturesSignPolling Leu/europa/ec/eudi/rqes/RSSPMethod;

--- a/src/main/kotlin/eu/europa/ec/eudi/rqes/RSSPMetadataResolver.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/rqes/RSSPMetadataResolver.kt
@@ -41,8 +41,8 @@ data class RSSPMetadataContent<T>(
     }
 }
 
-internal inline fun <reified T> RSSPMetadataContent<T>.oauth2AuthType(): AuthType.OAuth2<T>? =
-    authTypes.filterIsInstance<AuthType.OAuth2<T>>().firstOrNull()
+internal inline fun <reified T> RSSPMetadataContent<T>.oauth2AuthType(): OAuth2<T>? =
+    authTypes.filterIsInstance<OAuth2<T>>().firstOrNull()
 
 /**
  * The metadata of a RSSP.
@@ -64,10 +64,6 @@ enum class RSSPMethod {
     SignaturesSignDoc,
     SignaturesSignPolling,
     SignaturesTimestamp,
-    Oauth2Authorize,
-    Oauth2Token,
-    Oauth2PushedAuthorize,
-    Oauth2Revoke,
     ;
 
     companion object

--- a/src/main/kotlin/eu/europa/ec/eudi/rqes/internal/http/RSSPMetadataJsonParser.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/rqes/internal/http/RSSPMetadataJsonParser.kt
@@ -108,10 +108,6 @@ internal fun RSSPMethod.Companion.from(s: String): RSSPMethod? = when (s) {
     "signatures/signDoc" -> RSSPMethod.SignaturesSignDoc
     "signatures/signPolling" -> RSSPMethod.SignaturesSignPolling
     "signatures/timestamp" -> RSSPMethod.SignaturesTimestamp
-    "oauth2/authorize" -> RSSPMethod.Oauth2Authorize
-    "oauth2/token" -> RSSPMethod.Oauth2Token
-    "oauth2/pushed_authorize" -> RSSPMethod.Oauth2PushedAuthorize
-    "oauth2/revoke" -> RSSPMethod.Oauth2Revoke
     else -> null
 }
 

--- a/src/test/kotlin/eu/europa/ec/eudi/rqes/MockData.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/rqes/MockData.kt
@@ -113,13 +113,10 @@ private val methods = listOf(
     RSSPMethod.CredentialsAuthorize,
     RSSPMethod.CredentialsSendOTP,
     RSSPMethod.SignaturesSignHash,
-    RSSPMethod.Oauth2Authorize,
-    RSSPMethod.Oauth2Token,
-    RSSPMethod.Oauth2PushedAuthorize,
 )
 
 private val authorizationServerMetadata =
-    asMetadata(HttpsUrl("https://auth.domain.org").getOrThrow(), methods)
+    asMetadata(HttpsUrl("https://auth.domain.org").getOrThrow())
 
 internal val mockServiceAccessAuthorized = ServiceAccessAuthorized(
     OAuth2Tokens(

--- a/src/test/resources/eu/europa/ec/eudi/rqes/internal/rssp_metadata_valid.json
+++ b/src/test/resources/eu/europa/ec/eudi/rqes/internal/rssp_metadata_valid.json
@@ -22,11 +22,7 @@
     "credentials/info",
     "credentials/authorize",
     "credentials/sendOTP",
-    "signatures/signHash",
-    "oauth2/authorize",
-    "oauth2/token",
-    "oauth2/pushed_authorize",
-    "oauth2/revoke"
+    "signatures/signHash"
   ],
   "signAlgorithms": {
     "algos": [


### PR DESCRIPTION
When a RSSP is using the `oauth2` attribute in the `/info` endpoint to adevertise the OAuth2 server that protects it, there is no way to advertise the usage of PAR. In this case, if the library is configured to use PAR, it will try to use the PAR endpoint, and fallback to standard authorize flow if it fails.

Fixes #67 